### PR TITLE
Console bridge vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(console_bridge_vendor)
+
+find_package(ament_cmake REQUIRED)
+
+macro(build_console_bridge)
+  set(extra_cmake_args)
+  if(DEFINED CMAKE_BUILD_TYPE)
+    list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  endif()
+
+  include(ExternalProject)
+  ExternalProject_Add(console_bridge-0.4.0
+    URL https://github.com/ros/console_bridge/archive/0.4.0.tar.gz
+    URL_MD5 19a7b3ee7e99e41c1abd5c005418f50a
+    TIMEOUT 600
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+      ${extra_cmake_args}
+      -Wno-dev
+  )
+
+  # The external project will install to the build folder, but we'll install that on make install.
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}
+  )
+endmacro()
+
+find_package(console_bridge QUIET)
+
+if(NOT console_bridge_FOUND OR "${console_bridge_VERSION}" VERSION_LESS 0.4.0)
+  build_console_bridge()
+endif()
+
+# this ensures that the package has an environment hook setting the PATH
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,12 @@ macro(build_console_bridge)
   endif()
 
   include(ExternalProject)
-  ExternalProject_Add(console_bridge-0.4.0
-    URL https://github.com/ros/console_bridge/archive/0.4.0.tar.gz
-    URL_MD5 19a7b3ee7e99e41c1abd5c005418f50a
+  # Get console_bridge 0.4.0 + 2 patches:
+  # 4a52e5dfe6b8301bc18e472ad585ea216f3762f7: explicitly enable CMake policy 42 to prevent warning
+  # ad25f7307da76be2857545e7e5c2a20727eee542: use new version of gtest to fix windows warnings
+  ExternalProject_Add(console_bridge-ad25f73
+    URL https://github.com/ros/console_bridge/archive/ad25f7307da76be2857545e7e5c2a20727eee542.tar.gz
+    URL_MD5 5a7ab572593e2483ab1b08154c2af0b6
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>console_bridge_vendor</name>
+  <version>1.0.0</version>
+  <description>
+    Wrapper around console_bridge, providing nothing but a dependency on assimp, on some systems.
+    On others, it provides an ExternalProject build of console_bridge.
+  </description>
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
+  <license>Apache License 2.0</license>  <!-- the contents of this package are Apache 2.0 -->
+  <license>BSD</license>  <!-- console_bridge is BSD -->
+
+  <url type="website">https://github.com/ros/console_bridge</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>libconsole-bridge-dev</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Opening for visibility, waiting for CI to finish before placing in review

* Linux bionic: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4849)](http://ci.ros2.org/job/ci_linux/4849/)
* Linux xenial [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4851)](http://ci.ros2.org/job/ci_linux/4851/)
* Linux-aarch64 bionic [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1705)](http://ci.ros2.org/job/ci_linux-aarch64/1705/)
* Linux-aarch64 xenial [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1704)](http://ci.ros2.org/job/ci_linux-aarch64/1704/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4028)](http://ci.ros2.org/job/ci_osx/4028/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4894)](http://ci.ros2.org/job/ci_windows/4894/)
* tb2 demo  [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=134)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/134/)

CI including https://github.com/ros2/console_bridge_vendor/pull/1/commits/e3d93ae2ac42af2cbbafdcf53c20b0e4d4d451ea to fix warnings on windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4896)](http://ci.ros2.org/job/ci_windows/4896/)
