### PR TITLE
Require console_bridge 0.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,12 +36,10 @@ macro(build_console_bridge)
     endif()
   endif()
   include(ExternalProject)
-  # Get console_bridge 0.4.0 + 2 patches:
-  # 4a52e5dfe6b8301bc18e472ad585ea216f3762f7: explicitly enable CMake policy 42 to prevent warning
-  # ad25f7307da76be2857545e7e5c2a20727eee542: use new version of gtest to fix windows warnings
-  ExternalProject_Add(console_bridge-ad25f73
-    URL https://github.com/ros/console_bridge/archive/ad25f7307da76be2857545e7e5c2a20727eee542.tar.gz
-    URL_MD5 5a7ab572593e2483ab1b08154c2af0b6
+  # Get console_bridge 0.4.1
+  ExternalProject_Add(console_bridge-0.4.1
+    URL https://github.com/ros/console_bridge/archive/0.4.1.tar.gz
+    URL_MD5 6bb0f640db1712cf2277e7923e7bab68
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
@@ -60,7 +58,7 @@ endmacro()
 
 find_package(console_bridge QUIET)
 
-if(NOT console_bridge_FOUND OR "${console_bridge_VERSION}" VERSION_LESS 0.4.0)
+if(NOT console_bridge_FOUND OR "${console_bridge_VERSION}" VERSION_LESS 0.4.1)
   build_console_bridge()
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
     Wrapper around console_bridge, providing nothing but a dependency on console_bridge, on some systems.
     On others, it provides an ExternalProject build of console_bridge.
   </description>
-  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
+  <maintainer email="steven@osrfoundation.org">Steven! Ragnarök</maintainer>
   <license>Apache License 2.0</license>  <!-- the contents of this package are Apache 2.0 -->
   <license>BSD</license>  <!-- console_bridge is BSD -->
 


### PR DESCRIPTION
[console_bridge 0.4.1](https://github.com/ros/console_bridge/releases/tag/0.4.1) was released today and includes the two fixes we've been building in when vendoring console_bridge.

This updates the vendor code to check for 0.4.1 from the system and if it isn't found, will build it from source.

I snuck in a maintainer update because the last one I tried to do broke ament_lint on Windows and I wanted to check that it was "safe" to do so here.

