### PR TITLE
Add linters result in QD

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -96,7 +96,13 @@ The copyright holders each provide a statement of copyright in each source code 
 
 ### Linters and Static Analysis [4.v]
 
-`console_bridge_vendor` is not being tested with linters or static analysis tools.
+`console_bridge_vendor` is tested with `xmllint` and `lint_cmake` on [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers).
+
+Current nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/console_bridge_vendor/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/console_bridge_vendor/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/console_bridge_vendor/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/console_bridge_vendor/)
 
 ## Dependencies [5]
 


### PR DESCRIPTION
Updating `console_bridge_vendor` I realized current QD didn't mention linters applied to this package. This PR adds this missing information.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>