### PR TITLE
Enable basic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ macro(build_console_bridge)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
       -Wno-dev
+      -Wall
+      -Wextra
+      -Wpedantic
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
This PR enables `-Wall`, `-Wextra`, and `-Wpedantic`. No warnings were thrown by adding this.