### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ option(FORCE_BUILD_VENDOR_PKG
   "Build console_bridge from source, even if system-installed package is available"
   OFF)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 if(NOT FORCE_BUILD_VENDOR_PKG)
   find_package(console_bridge QUIET)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(FORCE_BUILD_VENDOR_PKG
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 if(NOT FORCE_BUILD_VENDOR_PKG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(FORCE_BUILD_VENDOR_PKG
   OFF)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
-if (POLICY CMP0135)
+if(POLICY CMP0135)
   cmake_policy(SET CMP0135 OLD)
 endif()
 


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in CMakeLists.txt

CI launch:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17257)](http://ci.ros2.org/job/ci_linux/17257/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11796)](http://ci.ros2.org/job/ci_linux-aarch64/11796/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17737)](http://ci.ros2.org/job/ci_windows/17737/)